### PR TITLE
Update error message for inquiry submissions to include wait time

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -648,7 +648,7 @@
 					<i class="fas fa-exclamation-circle"></i>
 				</div>
 				<h3>Oops!</h3>
-				<p>There was an error sending your message. Please try again later or contact us directly.</p>
+				<p>You've submitted too many inquiries. Please wait 24 hours before submitting another form or contact us directly.</p>
 				<button class="btn modal-btn">Close</button>
 			</div>
 		</div>


### PR DESCRIPTION
This pull request updates the user-facing error message in the `views/index.ejs` file to provide more specific feedback about submission limits.

User interface update:

* [`views/index.ejs`](diffhunk://#diff-1569f6145cede5d8e6ae231f567225ca24c0ab22477a9b04595114471af3c90aL651-R651): Updated the error message to inform users that they have submitted too many inquiries and need to wait 24 hours before submitting another form, replacing the generic error message.